### PR TITLE
Do not require slack when initializing

### DIFF
--- a/app/slackbot.go
+++ b/app/slackbot.go
@@ -22,6 +22,9 @@ var publishedRegexp = regexp.MustCompile(
 
 // runDeployBot runs the deploy bot that listens to messages in the slack channel
 func runDeployBot() {
+	if !slack.IsAvailable() {
+		return
+	}
 	mentionsRegexp, err := slack.MentionsRegexp()
 	if err != nil {
 		log.Error(err)

--- a/app/vili.go
+++ b/app/vili.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"sync"
 
+	"github.com/labstack/echo"
 	"github.com/viliproject/vili/api"
 	"github.com/viliproject/vili/auth"
 	"github.com/viliproject/vili/config"
@@ -23,7 +24,6 @@ import (
 	"github.com/viliproject/vili/stats"
 	"github.com/viliproject/vili/templates"
 	"github.com/viliproject/vili/util"
-	"github.com/labstack/echo"
 )
 
 const appName = "vili"
@@ -248,13 +248,15 @@ func New() *App {
 		// set up the slack service
 		func() {
 			defer wg.Done()
-			slack.Init(&slack.Config{
-				Token:           config.GetString(config.SlackToken),
-				Channel:         config.GetString(config.SlackChannel),
-				Username:        config.GetString(config.SlackUsername),
-				Emoji:           config.GetString(config.SlackEmoji),
-				DeployUsernames: util.NewStringSet(config.GetStringSlice(config.SlackDeployUsernames)),
-			})
+			if config.IsSet(config.SlackToken) {
+				slack.Init(&slack.Config{
+					Token:           config.GetString(config.SlackToken),
+					Channel:         config.GetString(config.SlackChannel),
+					Username:        config.GetString(config.SlackUsername),
+					Emoji:           config.GetString(config.SlackEmoji),
+					DeployUsernames: util.NewStringSet(config.GetStringSlice(config.SlackDeployUsernames)),
+				})
+			}
 		},
 		// set up the ci client
 		func() {

--- a/config/app.go
+++ b/config/app.go
@@ -94,7 +94,5 @@ func InitApp() error {
 		GithubOwner,
 		GithubRepo,
 		GithubContentsPath,
-		SlackToken,
-		SlackChannel,
 	)
 }

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/nlopes/slack"
 	"github.com/viliproject/vili/log"
 	"github.com/viliproject/vili/util"
-	"github.com/nlopes/slack"
 )
 
 // WaitGroup is the wait group to synchronize slack rtm shutdowns
@@ -36,6 +36,11 @@ func Init(c *Config) error {
 	config = c
 	client = slack.New(c.Token)
 	return nil
+}
+
+// IsAvailable returns whether slack is available
+func IsAvailable() bool {
+	return client != nil
 }
 
 // PostLogMessage posts a formatted log message to slack


### PR DESCRIPTION
Allow initializing and using vili without slack integration. This helps in cases where someone wants to get started quickly without setting up a Slack app and accompanying token, or simply wants to use vili without Slack.